### PR TITLE
fix: Update data file paths and correct typo in visualization notebooks

### DIFF
--- a/jupyter-notebooks/Visualize Image Information/matplotlib-visualization.ipynb
+++ b/jupyter-notebooks/Visualize Image Information/matplotlib-visualization.ipynb
@@ -151,7 +151,7 @@
    "outputs": [],
    "source": [
     "# File path on Google Drive\n",
-    "file_path = '/content/drive/My Drive/shared-data/Notebook datafiles/combined_csv_animal_flag_justanimals_location_flat.xlsx'"
+    "file_path = '/content/drive/My Drive/shared-data/Notebook datafiles/combined_animals.xlsx'"
    ]
   },
   {

--- a/jupyter-notebooks/Visualize Image Information/photo-select-tool.ipynb
+++ b/jupyter-notebooks/Visualize Image Information/photo-select-tool.ipynb
@@ -341,7 +341,7 @@
     "id": "cbc2bf00-e038-4145-bade-434429c2bc9d"
    },
    "source": [
-    "If `'y'` is the choice, it moves the images to the `select_dir`, the destination directoy."
+    "If `'y'` is the choice, it moves the images to the `select_dir`, the destination directory."
    ]
   },
   {

--- a/jupyter-notebooks/Visualize Image Information/sightings-bar-graph.ipynb
+++ b/jupyter-notebooks/Visualize Image Information/sightings-bar-graph.ipynb
@@ -184,7 +184,7 @@
    "outputs": [],
    "source": [
     "# Read the Excel file\n",
-    "file_path = '/content/drive/MyDrive/shared-data/Notebook datafiles/combined_csv_animal_flag_justanimals_location_flat.xlsx'  # Change this to the correct file path if necessary\n",
+    "file_path = '/content/drive/MyDrive/shared-data/Notebook datafiles/combined_animals.xlsx'  # Change this to the correct file path if necessary\n",
     "df = pd.read_excel(file_path)"
    ]
   },
@@ -505,7 +505,7 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "# Read the Excel file\n",
-    "file_path = '/content/drive/MyDrive/shared-data/Notebook datafiles/combined_csv_animal_flag_justanimals_location_flat.xlsx'\n",
+    "file_path = '/content/drive/MyDrive/shared-data/Notebook datafiles/combined_animals.xlsx'\n",
     "df = pd.read_excel(file_path)\n",
     "\n",
     "# Ensure the Date column is treated as a datetime object\n",
@@ -778,7 +778,7 @@
    "outputs": [],
    "source": [
     "# Read the Excel file\n",
-    "file_path = '/content/drive/MyDrive/shared-data/Notebook datafiles/combined_csv_animal_flag_justanimals_location_flat.xlsx'  # Change this to the correct file path if necessary\n",
+    "file_path = '/content/drive/MyDrive/shared-data/Notebook datafiles/combined_animals.xlsx'  # Change this to the correct file path if necessary\n",
     "df = pd.read_excel(file_path)"
    ]
   },

--- a/jupyter-notebooks/Visualize Image Information/tree-map.ipynb
+++ b/jupyter-notebooks/Visualize Image Information/tree-map.ipynb
@@ -184,7 +184,7 @@
    "outputs": [],
    "source": [
     "# Load the data into a Pandas dataframe\n",
-    "df = pd.read_excel(\"/content/drive/MyDrive/shared-data/Notebook datafiles/combined_csv_animal_flag_justanimals_location_flat.xlsx\")"
+    "df = pd.read_excel(\"/content/drive/MyDrive/shared-data/Notebook datafiles/combined_animals.xlsx\")"
    ]
   },
   {
@@ -500,7 +500,7 @@
    "outputs": [],
    "source": [
     "# Load the data\n",
-    "df = pd.read_excel(\"/content/drive/MyDrive/shared-data/Notebook datafiles/combined_csv_animal_flag_justanimals_location_flat.xlsx\")"
+    "df = pd.read_excel(\"/content/drive/MyDrive/shared-data/Notebook datafiles/combined_animals.xlsx\")"
    ]
   },
   {


### PR DESCRIPTION
- Update file path references from 'combined_csv_animal_flag_justanimals_location_flat.xlsx' to 'combined_animals.xlsx' across all visualization notebooks
- Fix typo in photo-select-tool.ipynb: changed 'directoy' to 'directory'
- Affected notebooks:
  - matplotlib-visualization.ipynb: Updated data file path
  - photo-select-tool.ipynb: Fixed typo in directory description
  - sightings-bar-graph.ipynb: Updated data file paths in 3 locations
  - tree-map.ipynb: Updated data file paths in 2 locations

These changes ensure consistent data file naming and improve documentation clarity.

🤖 Generated with [Claude Code](https://claude.ai/code)